### PR TITLE
PHN2 - Simulate LIDAR

### DIFF
--- a/description/rviz/view.rviz
+++ b/description/rviz/view.rviz
@@ -7,7 +7,7 @@ Panels:
         - /Global Options1
         - /Status1
         - /RobotModel1
-        - /RobotModel1/Status1
+        - /LaserScan1
       Splitter Ratio: 0.5
     Tree Height: 549
   - Class: rviz/Selection
@@ -93,12 +93,46 @@ Visualization Manager:
           Show Axes: false
           Show Trail: false
           Value: true
+        scan_link:
+          Alpha: 1
+          Show Axes: false
+          Show Trail: false
       Name: RobotModel
       Robot Description: photon/robot_description
       TF Prefix: photon
       Update Interval: 0
       Value: true
       Visual Enabled: true
+    - Alpha: 1
+      Autocompute Intensity Bounds: true
+      Autocompute Value Bounds:
+        Max Value: 10
+        Min Value: -10
+        Value: true
+      Axis: Z
+      Channel Name: intensity
+      Class: rviz/LaserScan
+      Color: 255; 255; 255
+      Color Transformer: ""
+      Decay Time: 0
+      Enabled: true
+      Invert Rainbow: false
+      Max Color: 255; 255; 255
+      Max Intensity: 4096
+      Min Color: 0; 0; 0
+      Min Intensity: 0
+      Name: LaserScan
+      Position Transformer: ""
+      Queue Size: 10
+      Selectable: true
+      Size (Pixels): 3
+      Size (m): 0.009999999776482582
+      Style: Flat Squares
+      Topic: ""
+      Unreliable: false
+      Use Fixed Frame: true
+      Use rainbow: true
+      Value: true
   Enabled: true
   Global Options:
     Background Color: 48; 48; 48
@@ -142,10 +176,10 @@ Visualization Manager:
       Invert Z Axis: false
       Name: Current View
       Near Clip Distance: 0.009999999776482582
-      Pitch: 0.785398006439209
+      Pitch: 0.10039889812469482
       Target Frame: <Fixed Frame>
       Value: Orbit (rviz)
-      Yaw: 0.785398006439209
+      Yaw: 2.6054024696350098
     Saved: ~
 Window Geometry:
   Displays:
@@ -164,4 +198,4 @@ Window Geometry:
     collapsed: false
   Width: 1200
   X: 67
-  Y: 30
+  Y: 27

--- a/description/urdf/constants.xacro
+++ b/description/urdf/constants.xacro
@@ -5,13 +5,12 @@
     <xacro:property name="fb_separation" value="0.286"/>
     <xacro:property name="lr_separation" value="0.304"/>
     <xacro:property name="height_to_wheel" value="-0.1135"/>
-    <xacro:property name="front_wheel" value="${fb_separation/2}"/>
 
     <!-- LIDAR -->
+    <xacro:property name="laser_visualize" value="false"/>
     <xacro:property name="laser_update_rate" value="10"/>
     <xacro:property name="laser_field_of_view" value="270"/>
     <xacro:property name="laser_min_range" value="0.06"/>
     <xacro:property name="laser_max_range" value="4.095"/>
 
 </robot>
-

--- a/description/urdf/constants.xacro
+++ b/description/urdf/constants.xacro
@@ -6,5 +6,12 @@
     <xacro:property name="lr_separation" value="0.304"/>
     <xacro:property name="height_to_wheel" value="-0.1135"/>
     <xacro:property name="front_wheel" value="${fb_separation/2}"/>
+
+    <!-- LIDAR -->
+    <xacro:property name="laser_update_rate" value="10"/>
+    <xacro:property name="laser_field_of_view" value="270"/>
+    <xacro:property name="laser_min_range" value="0.06"/>
+    <xacro:property name="laser_max_range" value="4.095"/>
+
 </robot>
 

--- a/description/urdf/constants.xacro
+++ b/description/urdf/constants.xacro
@@ -5,6 +5,6 @@
     <xacro:property name="fb_separation" value="0.286"/>
     <xacro:property name="lr_separation" value="0.304"/>
     <xacro:property name="height_to_wheel" value="-0.1135"/>
-
+    <xacro:property name="front_wheel" value="${fb_separation/2}"/>
 </robot>
 

--- a/description/urdf/cybertruck.urdf.xacro
+++ b/description/urdf/cybertruck.urdf.xacro
@@ -4,7 +4,7 @@
     <!-- Includes -->
     <xacro:include filename="$(find description)/urdf/constants.xacro"/>
     <xacro:include filename="$(find description)/urdf/inertias.xacro"/>
-    <!-- <xacro:include filename="$(find description)/urdf/plugins.gazebo.xacro"/> -->
+    <xacro:include filename="$(find description)/urdf/plugins.gazebo.xacro"/>
 
     <link name="base_link"/>
 

--- a/description/urdf/cybertruck.urdf.xacro
+++ b/description/urdf/cybertruck.urdf.xacro
@@ -44,7 +44,7 @@
     <joint name="scan_joint" type="fixed">
         <parent link="body_link"/>
         <child link="scan_link"/>
-        <origin xyz="0 ${front_wheel} ${-height_to_wheel}" rpy="0 0 0"/>
+        <origin xyz="0 ${fb_separation/2} ${-height_to_wheel}" rpy="0 0 0"/>
     </joint>
 
 </robot>

--- a/description/urdf/cybertruck.urdf.xacro
+++ b/description/urdf/cybertruck.urdf.xacro
@@ -4,7 +4,7 @@
     <!-- Includes -->
     <xacro:include filename="$(find description)/urdf/constants.xacro"/>
     <xacro:include filename="$(find description)/urdf/inertias.xacro"/>
-    <xacro:include filename="$(find description)/urdf/plugins.gazebo.xacro"/>
+    <xacro:include filename="$(find description)/urdf/lidar_plugin.gazebo.xacro"/>
 
     <link name="base_link"/>
 

--- a/description/urdf/cybertruck.urdf.xacro
+++ b/description/urdf/cybertruck.urdf.xacro
@@ -4,6 +4,7 @@
     <!-- Includes -->
     <xacro:include filename="$(find description)/urdf/constants.xacro"/>
     <xacro:include filename="$(find description)/urdf/inertias.xacro"/>
+    <!-- <xacro:include filename="$(find description)/urdf/plugins.gazebo.xacro"/> -->
 
     <link name="base_link"/>
 
@@ -36,6 +37,14 @@
 
     <!-- Wheels -->
     <xacro:include filename="$(find description)/urdf/wheels.urdf.xacro"/>
+    
+    <!-- LIDAR (also used for IMU) -->
+    <link name="scan_link"/>
+
+    <joint name="scan_joint" type="fixed">
+        <parent link="body_link"/>
+        <child link="scan_link"/>
+        <origin xyz="0 ${front_wheel} ${-height_to_wheel}" rpy="0 0 0"/>
+    </joint>
 
 </robot>
-

--- a/description/urdf/cybertruck.urdf.xacro
+++ b/description/urdf/cybertruck.urdf.xacro
@@ -4,7 +4,7 @@
     <!-- Includes -->
     <xacro:include filename="$(find description)/urdf/constants.xacro"/>
     <xacro:include filename="$(find description)/urdf/inertias.xacro"/>
-    <xacro:include filename="$(find description)/urdf/lidar_plugin.gazebo.xacro"/>
+    <xacro:include filename="$(find description)/urdf/plugins.gazebo.xacro"/>
 
     <link name="base_link"/>
 

--- a/description/urdf/lidar_plugin.gazebo.xacro
+++ b/description/urdf/lidar_plugin.gazebo.xacro
@@ -1,6 +1,7 @@
 <?xml version="1.0"?>
 <robot name="plugins" xmlns:xacro="http://ros.org/wiki/xacro">
-    <!-- Constants (Might not be needed for this file) -->
+    
+    <!-- Might use constants to change specific values-->
     <!-- <xacro:include filename="$(find description)/urdf/constants.xacro"/> -->
 
     <!-- LIDAR -->

--- a/description/urdf/lidar_plugin.gazebo.xacro
+++ b/description/urdf/lidar_plugin.gazebo.xacro
@@ -1,8 +1,8 @@
 <?xml version="1.0"?>
 <robot name="plugins" xmlns:xacro="http://ros.org/wiki/xacro">
     
-    <!-- Might use constants to change specific values-->
-    <!-- <xacro:include filename="$(find description)/urdf/constants.xacro"/> -->
+    <!-- Constants -->
+    <xacro:property name="laser_update_rate" value="10"/>
 
     <!-- LIDAR -->
     <gazebo reference="scan_link">
@@ -10,7 +10,8 @@
             <pose>0 0 0 0 0 0</pose>
             <!-- Set visualize to true for now -->
             <visualize>true</visualize>
-            <update_rate>30.0</update_rate>
+            <!-- Changed update rate from 30 to 10 -->
+            <update_rate>${laser_update_rate}</update_rate> 
             <ray>
                 <scan>
                     <horizontal>

--- a/description/urdf/plugins.gazebo.xacro
+++ b/description/urdf/plugins.gazebo.xacro
@@ -8,8 +8,7 @@
     <gazebo reference="scan_link">
         <sensor type="ray" name="gpu_hokuyo_sensor">
             <pose>0 0 0 0 0 0</pose>
-            <!-- Set visualize to true for now -->
-            <visualize>true</visualize>
+            <visualize>${laser_visualize}</visualize>
             <update_rate>${laser_update_rate}</update_rate> 
             <ray>
                 <scan>
@@ -39,6 +38,4 @@
         </sensor>
     </gazebo>
 
-
 </robot>
-

--- a/description/urdf/plugins.gazebo.xacro
+++ b/description/urdf/plugins.gazebo.xacro
@@ -26,9 +26,6 @@
                 </range>
                 <noise>
                     <type>gaussian</type>
-                    <!-- Noise based on gazebosim.org's tutorial on writing gazebo plugins w/ ROS. The comment they put will be reproduced:
-                        Noise parameters based on published spec for Hokuyo laser achieving "+-10mm" accuracy at range < 10 m. A mean of 
-                        0.0m and stddev of (0.01/3), will put 99.8% of samples within 0.03m of the true reading. -->
                     <mean>0.0</mean>
                     <stddev>${0.01/3}</stddev>
                 </noise>
@@ -40,3 +37,7 @@
             </plugin>
         </sensor>
     </gazebo>
+
+
+</robot>
+

--- a/description/urdf/plugins.gazebo.xacro
+++ b/description/urdf/plugins.gazebo.xacro
@@ -1,8 +1,8 @@
 <?xml version="1.0"?>
 <robot name="plugins" xmlns:xacro="http://ros.org/wiki/xacro">
-    
+
     <!-- Constants -->
-    <xacro:property name="laser_update_rate" value="10"/>
+    <xacro:include filename="$(find description)/urdf/constants.xacro"/>
 
     <!-- LIDAR -->
     <gazebo reference="scan_link">
@@ -10,21 +10,20 @@
             <pose>0 0 0 0 0 0</pose>
             <!-- Set visualize to true for now -->
             <visualize>true</visualize>
-            <!-- Changed update rate from 30 to 10 -->
             <update_rate>${laser_update_rate}</update_rate> 
             <ray>
                 <scan>
                     <horizontal>
                         <samples>1080</samples>
                         <resolution>1</resolution>
-                        <min_angle>${-0.5 * 270 * pi/180}</min_angle>
-                        <max_angle>${0.5 * 270 * pi/180}</max_angle>
+                        <min_angle>${-0.5*laser_field_of_view*pi/180}</min_angle>
+                        <max_angle>${0.5*laser_field_of_view*pi/180}</max_angle>
                     </horizontal>
                 </scan>
                 <range>
-                    <min>0.06</min>
-                    <max>4.095</max>
-                    <resolution>${0.36 * pi/180}</resolution>
+                    <min>${laser_min_range}</min>
+                    <max>${laser_max_range}</max>
+                    <resolution>${0.36* pi/180}</resolution>
                 </range>
                 <noise>
                     <type>gaussian</type>

--- a/description/urdf/plugins.gazebo.xacro
+++ b/description/urdf/plugins.gazebo.xacro
@@ -1,0 +1,42 @@
+<?xml version="1.0"?>
+<robot name="plugins" xmlns:xacro="http://ros.org/wiki/xacro">
+    <!-- Constants (Might not be needed for this file) -->
+    <!-- <xacro:include filename="$(find description)/urdf/constants.xacro"/> -->
+
+    <!-- LIDAR -->
+    <gazebo reference="scan_link">
+        <sensor type="ray" name="gpu_hokuyo_sensor">
+            <pose>0 0 0 0 0 0</pose>
+            <!-- Set visualize to true for now -->
+            <visualize>true</visualize>
+            <update_rate>30.0</update_rate>
+            <ray>
+                <scan>
+                    <horizontal>
+                        <samples>1080</samples>
+                        <resolution>1</resolution>
+                        <min_angle>${-0.5 * 270 * pi/180}</min_angle>
+                        <max_angle>${0.5 * 270 * pi/180}</max_angle>
+                    </horizontal>
+                </scan>
+                <range>
+                    <min>0.06</min>
+                    <max>4.095</max>
+                    <resolution>${0.36 * pi/180}</resolution>
+                </range>
+                <noise>
+                    <type>gaussian</type>
+                    <!-- Noise based on gazebosim.org's tutorial on writing gazebo plugins w/ ROS. The comment they put will be reproduced:
+                        Noise parameters based on published spec for Hokuyo laser achieving "+-10mm" accuracy at range < 10 m. A mean of 
+                        0.0m and stddev of (0.01/3), will put 99.8% of samples within 0.03m of the true reading. -->
+                    <mean>0.0</mean>
+                    <stddev>${0.01/3}</stddev>
+                </noise>
+            </ray>
+
+            <plugin name="gazebo_ros_hokuyo_controller" filename="libgazebo_ros_laser.so">
+                <topicName>scan</topicName>
+                <frameName>scan_link</frameName>
+            </plugin>
+        </sensor>
+    </gazebo>

--- a/description/urdf/plugins.gazebo.xacro
+++ b/description/urdf/plugins.gazebo.xacro
@@ -8,6 +8,7 @@
     <gazebo reference="scan_link">
         <sensor type="ray" name="gpu_hokuyo_sensor">
             <pose>0 0 0 0 0 0</pose>
+            <!-- TODO: Change values to actual lidar values-->
             <visualize>${laser_visualize}</visualize>
             <update_rate>${laser_update_rate}</update_rate> 
             <ray>


### PR DESCRIPTION
### PHN2 - Simulate LIDAR ###
assignees: MJ Cuevas

### Description ###

Added Lidar sensor to robot. Simulated on Gazebo with `roslaunch description simulate.launch`.

### Issues ###

Lidar values are unknown. Currently uses the Caffeine values for the lidar sensor.